### PR TITLE
x/cli: Expose a helper to write help message from a config struct pointer

### DIFF
--- a/configurator.go
+++ b/configurator.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/upfluence/cfg/internal/help"
 	"github.com/upfluence/cfg/internal/setter"
 	"github.com/upfluence/cfg/internal/walker"
 	"github.com/upfluence/cfg/provider"
@@ -27,7 +28,14 @@ func NewDefaultConfigurator(providers ...provider.Provider) Configurator {
 		append(providers, env.NewDefaultProvider(), flags.NewDefaultProvider())...,
 	)
 
-	return &helpConfigurator{configurator: cfg, stderr: os.Stderr}
+	return &helpConfigurator{
+		configurator: cfg,
+		hw: &help.Writer{
+			Providers: cfg.providers,
+			Factory:   cfg.factory,
+		},
+		stderr: os.Stderr,
+	}
 }
 
 func NewConfigurator(providers ...provider.Provider) Configurator {

--- a/help_configurator.go
+++ b/help_configurator.go
@@ -27,7 +27,7 @@ func (hc *helpConfigurator) Populate(ctx context.Context, in interface{}) error 
 	}
 
 	if cfg.Help {
-		hc.PrintDefaults(in)
+		_ = hc.PrintDefaults(in)
 		os.Exit(2)
 	}
 

--- a/help_configurator.go
+++ b/help_configurator.go
@@ -1,30 +1,21 @@
 package cfg
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os"
-	"strings"
 
-	"github.com/upfluence/cfg/internal/reflectutil"
-	"github.com/upfluence/cfg/internal/setter"
-	"github.com/upfluence/cfg/internal/walker"
-	"github.com/upfluence/cfg/provider"
+	"github.com/upfluence/cfg/internal/help"
 )
 
 type helpConfig struct {
 	Help bool `flag:"h,help" env:"HELP"`
 }
 
-var (
-	defaultHeaders = []byte("Arguments:\n")
-)
-
 type helpConfigurator struct {
 	*configurator
 
+	hw     *help.Writer
 	stderr io.Writer
 }
 
@@ -36,93 +27,14 @@ func (hc *helpConfigurator) Populate(ctx context.Context, in interface{}) error 
 	}
 
 	if cfg.Help {
-		hc.printDefaults(in)
+		hc.PrintDefaults(in)
 		os.Exit(2)
 	}
 
 	return hc.configurator.Populate(ctx, in)
 }
 
-func (hc *helpConfigurator) printDefaults(in interface{}) error {
-	hc.stderr.Write(defaultHeaders)
-
-	return walker.Walk(
-		in,
-		func(f *walker.Field) error {
-			s := hc.factory.Build(f.Field)
-
-			if s == nil {
-				return nil
-			}
-
-			fks := walker.BuildFieldKeys("", f)
-
-			if len(fks) == 0 {
-				return nil
-			}
-
-			if f.Value.Type().Implements(setter.ValueType) {
-				return walker.SkipStruct
-			}
-
-			var b bytes.Buffer
-
-			b.WriteString("\t- ")
-
-			b.WriteString(fks[0])
-
-			b.WriteString(": ")
-			b.WriteString(s.String())
-
-			if h, ok := f.Field.Tag.Lookup("help"); ok {
-				b.WriteString(" ")
-				b.WriteString(h)
-			}
-
-			fv := reflectutil.IndirectedValue(f.Value).FieldByName(f.Field.Name)
-			if !reflectutil.IsZero(fv) {
-				v := reflectutil.IndirectedValue(fv).Interface()
-
-				b.WriteString(" (default: ")
-
-				if ss, ok := v.(fmt.Stringer); ok {
-					b.WriteString(ss.String())
-				} else {
-					fmt.Fprintf(&b, "%+v", v)
-				}
-
-				b.WriteString(")")
-			}
-
-			var providedKeys []string
-
-			for _, p := range hc.providers {
-				if kf, ok := p.(provider.KeyFormatterProvider); ok {
-					var ks []string
-
-					for _, k := range walker.BuildFieldKeys(p.StructTag(), f) {
-						ks = append(ks, kf.FormatKey(k))
-					}
-
-					if len(ks) > 0 {
-						providedKeys = append(
-							providedKeys,
-							fmt.Sprintf("%s: %s", p.StructTag(), strings.Join(ks, ", ")),
-						)
-					}
-				}
-			}
-
-			if len(providedKeys) > 0 {
-				b.WriteString(" (")
-				b.WriteString(strings.Join(providedKeys, ", "))
-				b.WriteString(")")
-			}
-
-			b.WriteRune('\n')
-			b.WriteTo(hc.stderr)
-
-			return nil
-		},
-	)
+func (hc *helpConfigurator) PrintDefaults(in interface{}) error {
+	var _, err = hc.hw.Write(hc.stderr, in)
+	return err
 }

--- a/help_configurator_test.go
+++ b/help_configurator_test.go
@@ -45,8 +45,10 @@ func TestPrintDefaults(t *testing.T) {
 		)
 
 		cfg.stderr = &b
-		cfg.PrintDefaults(tt.in)
 
+		err := cfg.PrintDefaults(tt.in)
+
+		assert.NoError(t, err)
 		assert.Equal(t, tt.out, b.String())
 	}
 }

--- a/internal/help/writer.go
+++ b/internal/help/writer.go
@@ -1,0 +1,125 @@
+package help
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/upfluence/cfg/internal/reflectutil"
+	"github.com/upfluence/cfg/internal/setter"
+	"github.com/upfluence/cfg/internal/walker"
+	"github.com/upfluence/cfg/provider"
+	"github.com/upfluence/cfg/provider/env"
+	"github.com/upfluence/cfg/provider/flags"
+)
+
+var (
+	defaultHeaders = []byte("Arguments:\n")
+
+	DefaultWriter = &Writer{
+		Factory: setter.DefaultFactory,
+		Providers: []provider.Provider{
+			env.NewDefaultProvider(),
+			flags.NewDefaultProvider(),
+		},
+	}
+)
+
+type Writer struct {
+	Providers []provider.Provider
+	Factory   setter.Factory
+}
+
+func (w *Writer) Write(out io.Writer, in interface{}) (int, error) {
+	n, err := out.Write(defaultHeaders)
+
+	if err != nil {
+		return n, err
+	}
+
+	err = walker.Walk(
+		in,
+		func(f *walker.Field) error {
+			s := w.Factory.Build(f.Field)
+
+			if s == nil {
+				return nil
+			}
+
+			fks := walker.BuildFieldKeys("", f)
+
+			if len(fks) == 0 {
+				return nil
+			}
+
+			if f.Value.Type().Implements(setter.ValueType) {
+				return walker.SkipStruct
+			}
+
+			var b bytes.Buffer
+
+			b.WriteString("\t- ")
+
+			b.WriteString(fks[0])
+
+			b.WriteString(": ")
+			b.WriteString(s.String())
+
+			if h, ok := f.Field.Tag.Lookup("help"); ok {
+				b.WriteString(" ")
+				b.WriteString(h)
+			}
+
+			fv := reflectutil.IndirectedValue(f.Value).FieldByName(f.Field.Name)
+			if !reflectutil.IsZero(fv) {
+				v := reflectutil.IndirectedValue(fv).Interface()
+
+				b.WriteString(" (default: ")
+
+				if ss, ok := v.(fmt.Stringer); ok {
+					b.WriteString(ss.String())
+				} else {
+					fmt.Fprintf(&b, "%+v", v)
+				}
+
+				b.WriteString(")")
+			}
+
+			var providedKeys []string
+
+			for _, p := range w.Providers {
+				if kf, ok := p.(provider.KeyFormatterProvider); ok {
+					var ks []string
+
+					for _, k := range walker.BuildFieldKeys(p.StructTag(), f) {
+						ks = append(ks, kf.FormatKey(k))
+					}
+
+					if len(ks) > 0 {
+						providedKeys = append(
+							providedKeys,
+							fmt.Sprintf("%s: %s", p.StructTag(), strings.Join(ks, ", ")),
+						)
+					}
+				}
+			}
+
+			if len(providedKeys) > 0 {
+				b.WriteString(" (")
+				b.WriteString(strings.Join(providedKeys, ", "))
+				b.WriteString(")")
+			}
+
+			b.WriteRune('\n')
+
+			nn, err := b.WriteTo(out)
+
+			n += int(nn)
+
+			return err
+		},
+	)
+
+	return n, err
+}

--- a/internal/help/writer_test.go
+++ b/internal/help/writer_test.go
@@ -1,9 +1,8 @@
-package cfg
+package help
 
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -12,26 +11,18 @@ type helpStructConfig struct {
 	Yolo string `help:"this is the help message" flag:"yolo,y"`
 }
 
+type mapStringIntStruct struct {
+	Map map[string]int `mock:"map"`
+}
+
 func TestPrintDefaults(t *testing.T) {
 	for _, tt := range []struct {
 		in  interface{}
 		out string
 	}{
 		{
-			in:  &mapStringIntStruct{},
-			out: "Arguments:\n\t- Map: map[string]integer (env: MAP, flag: --map)\n",
-		},
-		{
 			in:  &mapStringIntStruct{Map: map[string]int{"fiz": 42}},
 			out: "Arguments:\n\t- Map: map[string]integer (default: map[fiz:42]) (env: MAP, flag: --map)\n",
-		},
-		{
-			in:  &nestedPtrStruct{},
-			out: "Arguments:\n\t- Nested.Inner: integer (env: NESTED_INNER, flag: --nested.inner)\n",
-		},
-		{
-			in:  &durationStruct{D: 5 * time.Hour},
-			out: "Arguments:\n\t- D: duration (default: 5h0m0s) (env: D, flag: -d)\n",
 		},
 		{
 			in:  &helpStructConfig{},
@@ -41,12 +32,10 @@ func TestPrintDefaults(t *testing.T) {
 		var (
 			b bytes.Buffer
 
-			cfg = NewDefaultConfigurator().(*helpConfigurator)
+			_, err = DefaultWriter.Write(&b, tt.in)
 		)
 
-		cfg.stderr = &b
-		cfg.PrintDefaults(tt.in)
-
+		assert.NoError(t, err)
 		assert.Equal(t, tt.out, b.String())
 	}
 }

--- a/x/cli/app.go
+++ b/x/cli/app.go
@@ -105,7 +105,7 @@ func (a *App) Run(ctx context.Context) {
 			code = serr.StatusCode()
 		}
 
-		io.WriteString(os.Stderr, err.Error())
+		io.WriteString(os.Stderr, err.Error()+"\n")
 	}
 
 	os.Stdout.Sync()

--- a/x/cli/app.go
+++ b/x/cli/app.go
@@ -105,7 +105,7 @@ func (a *App) Run(ctx context.Context) {
 			code = serr.StatusCode()
 		}
 
-		io.WriteString(os.Stderr, err.Error()+"\n")
+		_, _ = io.WriteString(os.Stderr, err.Error()+"\n")
 	}
 
 	os.Stdout.Sync()

--- a/x/cli/command.go
+++ b/x/cli/command.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/upfluence/cfg"
+	"github.com/upfluence/cfg/internal/help"
 	"github.com/upfluence/cfg/internal/walker"
 	"github.com/upfluence/cfg/provider/flags"
 )
@@ -236,6 +237,12 @@ func (sc StaticCommand) WriteSynopsis(w io.Writer) (int, error) {
 
 func (sc StaticCommand) Run(ctx context.Context, cctx CommandContext) error {
 	return sc.Execute(ctx, cctx)
+}
+
+func HelpWriter(in interface{}) func(io.Writer) (int, error) {
+	return func(w io.Writer) (int, error) {
+		return help.DefaultWriter.Write(w, in)
+	}
 }
 
 func SynopsisWriter(in interface{}) func(io.Writer) (int, error) {


### PR DESCRIPTION
### What does this PR do?

Allows cli user to create a auto generated help message from the config struct. It display, the name, the type, the default value as well as the field name in each provider

### What are the observable changes?

You can see it in action in prometheus-uds-sync `rule-sync -h`

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
