### PR TITLE
Add the capacity of skipping a field providing

### DIFF
--- a/configurator_test.go
+++ b/configurator_test.go
@@ -168,6 +168,10 @@ type mapStringIntStruct struct {
 	Map map[string]int `mock:"map"`
 }
 
+type skipStruct struct {
+	Foo string `mock:"-"`
+}
+
 func boolTestCase(in string, out bool) testCase {
 	return testCase{
 		input:         &basicStructBool{},
@@ -424,6 +428,18 @@ func TestConfigurator(t *testing.T) {
 			dataAssertion: func(t *testing.T, y interface{}) {
 				if v := y.(*mutiValuesStruct).Foo; v != "123" {
 					t.Errorf("Wrong result set: %v [ instead of: %v]", v, "123")
+				}
+			},
+			errAssertion: noError,
+		},
+
+		testCase{
+			input:    &skipStruct{},
+			caseName: "use - to skip providing",
+			provider: &mockProvider{st: map[string]string{"Foo": "123"}},
+			dataAssertion: func(t *testing.T, y interface{}) {
+				if v := y.(*skipStruct).Foo; v != "" {
+					t.Errorf("Wrong result set: %v [ instead of: \"\"]", v)
 				}
 			},
 			errAssertion: noError,

--- a/internal/help/writer.go
+++ b/internal/help/writer.go
@@ -105,11 +105,13 @@ func (w *Writer) Write(out io.Writer, in interface{}) (int, error) {
 				}
 			}
 
-			if len(providedKeys) > 0 {
-				b.WriteString(" (")
-				b.WriteString(strings.Join(providedKeys, ", "))
-				b.WriteString(")")
+			if len(providedKeys) == 0 {
+				return nil
 			}
+
+			b.WriteString(" (")
+			b.WriteString(strings.Join(providedKeys, ", "))
+			b.WriteString(")")
 
 			b.WriteRune('\n')
 

--- a/internal/help/writer_test.go
+++ b/internal/help/writer_test.go
@@ -16,8 +16,15 @@ type mapStringIntStruct struct {
 }
 
 type nestedStruct struct {
-	Sub mapStringIntStruct `env:"-" flag:"-"`
+	Sub    mapStringIntStruct `env:"-" flag:"-"`
+	Parser parserImpl
 }
+
+type parserImpl struct {
+	Foo string
+}
+
+func (*parserImpl) Parse(string) error { return nil }
 
 func TestPrintDefaults(t *testing.T) {
 	for _, tt := range []struct {
@@ -34,7 +41,7 @@ func TestPrintDefaults(t *testing.T) {
 		},
 		{
 			in:  &nestedStruct{},
-			out: "Arguments:\n",
+			out: "Arguments:\n\t- Parser: help.parserImpl (env: PARSER, flag: --parser)\n",
 		},
 	} {
 		var (

--- a/internal/help/writer_test.go
+++ b/internal/help/writer_test.go
@@ -8,11 +8,15 @@ import (
 )
 
 type helpStructConfig struct {
-	Yolo string `help:"this is the help message" flag:"yolo,y"`
+	Yolo string `help:"this is the help message" flag:"yolo,y" env:"-"`
 }
 
 type mapStringIntStruct struct {
 	Map map[string]int `mock:"map"`
+}
+
+type nestedStruct struct {
+	Sub mapStringIntStruct `env:"-" flag:"-"`
 }
 
 func TestPrintDefaults(t *testing.T) {
@@ -26,7 +30,11 @@ func TestPrintDefaults(t *testing.T) {
 		},
 		{
 			in:  &helpStructConfig{},
-			out: "Arguments:\n\t- Yolo: string this is the help message (env: YOLO, flag: --yolo, -y)\n",
+			out: "Arguments:\n\t- Yolo: string this is the help message (flag: --yolo, -y)\n",
+		},
+		{
+			in:  &nestedStruct{},
+			out: "Arguments:\n",
 		},
 	} {
 		var (

--- a/internal/reflectutil/value.go
+++ b/internal/reflectutil/value.go
@@ -22,6 +22,14 @@ func IsZero(v reflect.Value) bool {
 		}
 
 		return IsZero(v.Elem())
+	case reflect.Struct:
+		for i := 0; i < v.Type().NumField(); i++ {
+			if !IsZero(v.Field(i)) {
+				return false
+			}
+		}
+
+		return true
 	}
 
 	return false

--- a/internal/synopsis/writer.go
+++ b/internal/synopsis/writer.go
@@ -1,0 +1,62 @@
+package synopsis
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/upfluence/cfg/internal/setter"
+	"github.com/upfluence/cfg/internal/walker"
+	"github.com/upfluence/cfg/provider"
+	"github.com/upfluence/cfg/provider/flags"
+)
+
+var DefaultWriter = &Writer{
+	Factory:  setter.DefaultFactory,
+	Provider: flags.NewProvider(nil),
+}
+
+type Writer struct {
+	Factory  setter.Factory
+	Provider provider.KeyFormatterProvider
+}
+
+func (w *Writer) Write(out io.Writer, in interface{}) (int, error) {
+	var b bytes.Buffer
+
+	if err := walker.Walk(
+		in,
+		func(f *walker.Field) error {
+			if s := w.Factory.Build(f.Field); s == nil {
+				return nil
+			}
+
+			fks := walker.BuildFieldKeys(w.Provider.StructTag(), f)
+
+			if len(fks) == 0 {
+				return nil
+			}
+
+			if f.Value.Type().Implements(setter.ValueType) {
+				return walker.SkipStruct
+			}
+
+			b.WriteRune('[')
+
+			for i, fk := range fks {
+				b.WriteString(w.Provider.FormatKey(fk))
+
+				if i < len(fks)-1 {
+					b.WriteString(", ")
+				}
+			}
+
+			b.WriteString("] ")
+
+			return nil
+		},
+	); err != nil {
+		return 0, err
+	}
+
+	return out.Write(b.Bytes())
+}

--- a/internal/synopsis/writer_test.go
+++ b/internal/synopsis/writer_test.go
@@ -1,0 +1,57 @@
+package synopsis
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type helpStructConfig struct {
+	Yolo string `flag:"yolo,y"`
+	Bar  string
+}
+
+type mapStringIntStruct struct {
+	Map map[string]int `flag:"map"`
+}
+
+type nestedStruct struct {
+	Sub    mapStringIntStruct `flag:"-"`
+	Parser *parserImpl
+}
+
+type parserImpl struct {
+	Foo string
+}
+
+func (*parserImpl) Parse(string) error { return nil }
+
+func TestPrintDefaults(t *testing.T) {
+	for _, tt := range []struct {
+		in  interface{}
+		out string
+	}{
+		{
+			in:  &mapStringIntStruct{Map: map[string]int{"fiz": 42}},
+			out: "[--map] ",
+		},
+		{
+			in:  &helpStructConfig{},
+			out: "[--yolo, -y] [--bar] ",
+		},
+		{
+			in:  &nestedStruct{},
+			out: "[--parser] ",
+		},
+	} {
+		var (
+			b bytes.Buffer
+
+			_, err = DefaultWriter.Write(&b, tt.in)
+		)
+
+		assert.NoError(t, err)
+		assert.Equal(t, tt.out, b.String())
+	}
+}

--- a/provider/flags/provider.go
+++ b/provider/flags/provider.go
@@ -53,11 +53,11 @@ func parseFlags(args []string) map[string]string {
 	return res
 }
 
-func NewDefaultProvider() provider.Provider {
+func NewDefaultProvider() provider.KeyFormatterProvider {
 	return NewProvider(os.Args[1:])
 }
 
-func NewProvider(args []string) provider.Provider {
+func NewProvider(args []string) provider.KeyFormatterProvider {
 	return provider.KeyFormatterFunc{
 		Provider: provider.NewStaticProvider(
 			StructTag,

--- a/x/cli/command.go
+++ b/x/cli/command.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -10,8 +9,7 @@ import (
 
 	"github.com/upfluence/cfg"
 	"github.com/upfluence/cfg/internal/help"
-	"github.com/upfluence/cfg/internal/walker"
-	"github.com/upfluence/cfg/provider/flags"
+	"github.com/upfluence/cfg/internal/synopsis"
 )
 
 type CommandContext struct {
@@ -247,40 +245,6 @@ func HelpWriter(in interface{}) func(io.Writer) (int, error) {
 
 func SynopsisWriter(in interface{}) func(io.Writer) (int, error) {
 	return func(w io.Writer) (int, error) {
-		var b bytes.Buffer
-
-		if err := walker.Walk(
-			in,
-			func(f *walker.Field) error {
-				fks := walker.BuildFieldKeys(flags.StructTag, f)
-
-				if len(fks) == 0 {
-					return nil
-				}
-
-				b.WriteRune('[')
-
-				for i, fk := range fks {
-					b.WriteRune('-')
-
-					if len(fk) > 1 {
-						b.WriteRune('-')
-					}
-
-					b.WriteString(fk)
-
-					if i < len(fks)-1 {
-						b.WriteString(", ")
-					}
-				}
-
-				b.WriteString("] ")
-				return nil
-			},
-		); err != nil {
-			return 0, err
-		}
-
-		return w.Write(b.Bytes())
+		return synopsis.DefaultWriter.Write(w, in)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This pull requests allows the user to skip the providing of a given field or nesting of fields by a given provider.

It works the same way as `encoding/json` does it ( `json:"-"`). Here you need to add the tag as:
```
`<provider_key>:"-"`
```

to skip it. 

### What are the observable changes?

It should impact the Populate result and the help output, checkout the test files to know more about it.

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
