### PR TITLE
Expose publicly the parser API 

### DIFF
--- a/internal/help/writer.go
+++ b/internal/help/writer.go
@@ -41,7 +41,7 @@ func (w *Writer) Write(out io.Writer, in interface{}) (int, error) {
 	err = walker.Walk(
 		in,
 		func(f *walker.Field) error {
-			s := w.Factory.Build(f.Field)
+			s := w.Factory.Build(f.Field.Type)
 
 			if s == nil {
 				return nil

--- a/internal/setter/setter.go
+++ b/internal/setter/setter.go
@@ -61,7 +61,7 @@ func NewDefaultFactory(opts ...FactoryOption) Factory {
 	return &defaultFactory{opts: o}
 }
 
-func (dsf *defaultFactory) buildBasicParser(t reflect.Type) (parser, bool) {
+func (df *defaultFactory) buildBasicParser(t reflect.Type) (parser, bool) {
 	var (
 		k  = t.Kind()
 		pt = t
@@ -82,7 +82,7 @@ func (dsf *defaultFactory) buildBasicParser(t reflect.Type) (parser, bool) {
 	}
 
 	if p, ok := presetParsers[t]; ok {
-		return p(dsf.opts), ptr
+		return p(df.opts), ptr
 	}
 
 	switch k {
@@ -99,12 +99,12 @@ func (dsf *defaultFactory) buildBasicParser(t reflect.Type) (parser, bool) {
 	return nil, false
 }
 
-func (dsf *defaultFactory) buildParser(t reflect.Type) parser {
+func (df *defaultFactory) buildParser(t reflect.Type) parser {
 	k := t.Kind()
 
 	switch k {
 	case reflect.Slice:
-		p, ptr := dsf.buildBasicParser(t.Elem())
+		p, ptr := df.buildBasicParser(t.Elem())
 
 		if p == nil {
 			return nil
@@ -112,13 +112,13 @@ func (dsf *defaultFactory) buildParser(t reflect.Type) parser {
 
 		return &sliceParser{p: p, t: t, ptr: ptr}
 	case reflect.Map:
-		vp, vptr := dsf.buildBasicParser(t.Elem())
+		vp, vptr := df.buildBasicParser(t.Elem())
 
 		if vp == nil {
 			return nil
 		}
 
-		kp, kptr := dsf.buildBasicParser(t.Key())
+		kp, kptr := df.buildBasicParser(t.Key())
 
 		if kp == nil {
 			return nil
@@ -127,7 +127,7 @@ func (dsf *defaultFactory) buildParser(t reflect.Type) parser {
 		return &mapParser{t: t, vp: vp, vptr: vptr, kp: kp, kptr: kptr}
 	}
 
-	p, _ := dsf.buildBasicParser(t)
+	p, _ := df.buildBasicParser(t)
 
 	return p
 }

--- a/internal/synopsis/writer.go
+++ b/internal/synopsis/writer.go
@@ -26,7 +26,7 @@ func (w *Writer) Write(out io.Writer, in interface{}) (int, error) {
 	if err := walker.Walk(
 		in,
 		func(f *walker.Field) error {
-			if s := w.Factory.Build(f.Field); s == nil {
+			if s := w.Factory.Build(f.Field.Type); s == nil {
 				return nil
 			}
 

--- a/x/parser/parser.go
+++ b/x/parser/parser.go
@@ -1,0 +1,39 @@
+package parser
+
+import (
+	"errors"
+	"reflect"
+
+	"github.com/upfluence/cfg/internal/reflectutil"
+	"github.com/upfluence/cfg/internal/setter"
+)
+
+var (
+	ErrShouldBePtr = errors.New("x/parser: input should be a pointer")
+
+	WithDateFormat = setter.WithDateFormat
+)
+
+type ParserOption = setter.FactoryOption
+
+type Parser struct {
+	sf setter.Factory
+}
+
+func NewParser(opts ...ParserOption) *Parser {
+	return &Parser{sf: setter.NewDefaultFactory(opts...)}
+}
+
+func (p *Parser) Parse(data string, target interface{}) error {
+	v := reflect.ValueOf(target)
+
+	if v.Kind() != reflect.Ptr {
+		return ErrShouldBePtr
+	}
+
+	return p.sf.Build(v.Type()).Set(data, reflectutil.IndirectedValue(v))
+}
+
+func Parse(data string, target interface{}, opts ...ParserOption) error {
+	return NewParser(opts...).Parse(data, target)
+}

--- a/x/parser/parser.go
+++ b/x/parser/parser.go
@@ -14,13 +14,13 @@ var (
 	WithDateFormat = setter.WithDateFormat
 )
 
-type ParserOption = setter.FactoryOption
+type Option = setter.FactoryOption
 
 type Parser struct {
 	sf setter.Factory
 }
 
-func NewParser(opts ...ParserOption) *Parser {
+func NewParser(opts ...Option) *Parser {
 	return &Parser{sf: setter.NewDefaultFactory(opts...)}
 }
 
@@ -34,6 +34,6 @@ func (p *Parser) Parse(data string, target interface{}) error {
 	return p.sf.Build(v.Type()).Set(data, reflectutil.IndirectedValue(v))
 }
 
-func Parse(data string, target interface{}, opts ...ParserOption) error {
+func Parse(data string, target interface{}, opts ...Option) error {
 	return NewParser(opts...).Parse(data, target)
 }

--- a/x/parser/parser_test.go
+++ b/x/parser/parser_test.go
@@ -1,0 +1,22 @@
+package parser
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	var t0 time.Time
+
+	err := Parse("1970-01-02", &t0, WithDateFormat("2006-01-02"))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(86400), t0.Unix())
+
+	var vs []int64
+
+	err = Parse("1,2,3", &vs)
+	assert.NoError(t, err)
+	assert.Equal(t, []int64{1, 2, 3}, vs)
+}


### PR DESCRIPTION
### What does this PR do?

I added a x/parser package, to allow 3rd party apps to use the setter internal part of this repo without having to pass by a full configurator, it should not become the go to but it will definetly useful with legacy code.

As im not sure about the actual API i put it in its own standalone experimental package

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
