### PR TITLE
Better help and synopsis writing

### DIFF
--- a/example/kubectl/kubectl.go
+++ b/example/kubectl/kubectl.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/upfluence/cfg/x/cli"
+)
+
+type config struct {
+	Namespace     string `flag:"n,namespace"`
+	RessourceType string `arg:"resource_type"`
+	RessourceName string `arg:"resource_name"`
+}
+
+type leafCommandExecutor string
+
+func (lce leafCommandExecutor) execute(ctx context.Context, cctx cli.CommandContext) error {
+	var c config
+
+	if err := cctx.Configurator.Populate(ctx, &c); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(
+		cctx.Stdout,
+		"action=%q namespace=%q ressourceType=%q ressourceName=%q",
+		lce,
+		c.Namespace,
+		c.RessourceType,
+		c.RessourceName,
+	)
+
+	return nil
+}
+
+func buildObjectCommand(cmd, desc string) cli.Command {
+	return cli.ArgumentCommand{
+		Variable: "resource_type",
+		Command: cli.ArgumentCommand{
+			Variable: "resource_name",
+			Command: cli.StaticCommand{
+				Help:    cli.StaticString(desc),
+				Execute: leafCommandExecutor(cmd).execute,
+			},
+		},
+	}
+}
+
+func main() {
+	cli.NewApp(
+		cli.WithName("kubectl"),
+		cli.WithCommand(
+			cli.SubCommand{
+				Variable: "verb",
+				Commands: map[string]cli.Command{
+					"describe": buildObjectCommand("describe", "describe remote object"),
+					"edit":     buildObjectCommand("edit", "edit remote object"),
+				},
+			},
+		),
+	).Run(context.Background())
+}

--- a/internal/help/writer.go
+++ b/internal/help/writer.go
@@ -31,97 +31,103 @@ type Writer struct {
 	Factory   setter.Factory
 }
 
-func (w *Writer) Write(out io.Writer, in interface{}) (int, error) {
+func (w *Writer) Write(out io.Writer, ins ...interface{}) (int, error) {
 	n, err := out.Write(defaultHeaders)
 
 	if err != nil {
 		return n, err
 	}
 
-	err = walker.Walk(
-		in,
-		func(f *walker.Field) error {
-			s := w.Factory.Build(f.Field.Type)
+	for _, in := range ins {
+		err = walker.Walk(
+			in,
+			func(f *walker.Field) error {
+				s := w.Factory.Build(f.Field.Type)
 
-			if s == nil {
-				return nil
-			}
-
-			fks := walker.BuildFieldKeys("", f)
-
-			if len(fks) == 0 {
-				return nil
-			}
-
-			if f.Value.Type().Implements(setter.ValueType) {
-				return walker.SkipStruct
-			}
-
-			var b bytes.Buffer
-
-			b.WriteString("\t- ")
-
-			b.WriteString(fks[0])
-
-			b.WriteString(": ")
-			b.WriteString(s.String())
-
-			if h, ok := f.Field.Tag.Lookup("help"); ok {
-				b.WriteString(" ")
-				b.WriteString(h)
-			}
-
-			fv := reflectutil.IndirectedValue(f.Value).FieldByName(f.Field.Name)
-			if !reflectutil.IsZero(fv) {
-				v := reflectutil.IndirectedValue(fv).Interface()
-
-				b.WriteString(" (default: ")
-
-				if ss, ok := v.(fmt.Stringer); ok {
-					b.WriteString(ss.String())
-				} else {
-					fmt.Fprintf(&b, "%+v", v)
+				if s == nil {
+					return nil
 				}
 
+				fks := walker.BuildFieldKeys("", f)
+
+				if len(fks) == 0 {
+					return nil
+				}
+
+				if f.Value.Type().Implements(setter.ValueType) {
+					return walker.SkipStruct
+				}
+
+				var b bytes.Buffer
+
+				b.WriteString("\t- ")
+
+				b.WriteString(fks[0])
+
+				b.WriteString(": ")
+				b.WriteString(s.String())
+
+				if h, ok := f.Field.Tag.Lookup("help"); ok {
+					b.WriteString(" ")
+					b.WriteString(h)
+				}
+
+				fv := reflectutil.IndirectedValue(f.Value).FieldByName(f.Field.Name)
+				if !reflectutil.IsZero(fv) {
+					v := reflectutil.IndirectedValue(fv).Interface()
+
+					b.WriteString(" (default: ")
+
+					if ss, ok := v.(fmt.Stringer); ok {
+						b.WriteString(ss.String())
+					} else {
+						fmt.Fprintf(&b, "%+v", v)
+					}
+
+					b.WriteString(")")
+				}
+
+				var providedKeys []string
+
+				for _, p := range w.Providers {
+					if kf, ok := p.(provider.KeyFormatterProvider); ok {
+						var ks []string
+
+						for _, k := range walker.BuildFieldKeys(p.StructTag(), f) {
+							ks = append(ks, kf.FormatKey(k))
+						}
+
+						if len(ks) > 0 {
+							providedKeys = append(
+								providedKeys,
+								fmt.Sprintf("%s: %s", p.StructTag(), strings.Join(ks, ", ")),
+							)
+						}
+					}
+				}
+
+				if len(providedKeys) == 0 {
+					return nil
+				}
+
+				b.WriteString(" (")
+				b.WriteString(strings.Join(providedKeys, ", "))
 				b.WriteString(")")
-			}
 
-			var providedKeys []string
+				b.WriteRune('\n')
 
-			for _, p := range w.Providers {
-				if kf, ok := p.(provider.KeyFormatterProvider); ok {
-					var ks []string
+				nn, err := b.WriteTo(out)
 
-					for _, k := range walker.BuildFieldKeys(p.StructTag(), f) {
-						ks = append(ks, kf.FormatKey(k))
-					}
+				n += int(nn)
 
-					if len(ks) > 0 {
-						providedKeys = append(
-							providedKeys,
-							fmt.Sprintf("%s: %s", p.StructTag(), strings.Join(ks, ", ")),
-						)
-					}
-				}
-			}
+				return err
+			},
+		)
 
-			if len(providedKeys) == 0 {
-				return nil
-			}
+		if err != nil {
+			return n, err
+		}
+	}
 
-			b.WriteString(" (")
-			b.WriteString(strings.Join(providedKeys, ", "))
-			b.WriteString(")")
-
-			b.WriteRune('\n')
-
-			nn, err := b.WriteTo(out)
-
-			n += int(nn)
-
-			return err
-		},
-	)
-
-	return n, err
+	return n, nil
 }

--- a/x/cli/app.go
+++ b/x/cli/app.go
@@ -95,6 +95,7 @@ func (a *App) commandContext() CommandContext {
 		Stdout:       os.Stdout,
 		Stderr:       os.Stderr,
 		args:         args,
+		appName:      a.name,
 	}
 }
 

--- a/x/cli/argument_command.go
+++ b/x/cli/argument_command.go
@@ -11,16 +11,35 @@ type ArgumentCommand struct {
 	Command  Command
 }
 
-func (sc ArgumentCommand) WriteSynopsis(w io.Writer) (int, error) {
-	return sc.Command.WriteSynopsis(w)
+func (sc ArgumentCommand) definition() CommandDefinition {
+	return CommandDefinition{Args: []string{sc.Variable}}
 }
 
-func (sc ArgumentCommand) WriteHelp(w io.Writer) (int, error) {
-	return sc.Command.WriteHelp(w)
+func (sc ArgumentCommand) WriteSynopsis(w io.Writer, opts IntrospectionOptions) (int, error) {
+	return sc.Command.WriteSynopsis(w, opts.withDefinition(sc.definition()))
+}
+
+func (sc ArgumentCommand) WriteHelp(w io.Writer, opts IntrospectionOptions) (int, error) {
+	return sc.Command.WriteHelp(w, opts.withDefinition(sc.definition()))
 }
 
 func (sc ArgumentCommand) Run(ctx context.Context, cctx CommandContext) error {
 	if len(cctx.Args) == 0 {
+		ok, err := isHelpRequested(ctx, cctx)
+
+		if err != nil {
+			return err
+		}
+
+		if ok {
+			_, err := sc.WriteHelp(
+				cctx.Stderr,
+				IntrospectionOptions{Definitions: cctx.Definitions},
+			)
+
+			return err
+		}
+
 		if _, err := fmt.Fprintf(
 			cctx.Stderr,
 			"no argument found for variable %q, follow the synopsis:\n",
@@ -29,12 +48,17 @@ func (sc ArgumentCommand) Run(ctx context.Context, cctx CommandContext) error {
 			return err
 		}
 
-		_, err := sc.WriteSynopsis(cctx.Stderr)
+		_, err = sc.WriteSynopsis(
+			cctx.Stderr,
+			IntrospectionOptions{Definitions: cctx.Definitions},
+		)
+
 		return err
 	}
 
 	subject := cctx.Args[0]
 	cctx.Args = cctx.Args[1:]
+	cctx.Definitions = append(cctx.Definitions, sc.definition())
 	cctx.args[sc.Variable] = subject
 
 	return sc.Command.Run(ctx, cctx)

--- a/x/cli/argument_command.go
+++ b/x/cli/argument_command.go
@@ -32,11 +32,7 @@ func (sc ArgumentCommand) Run(ctx context.Context, cctx CommandContext) error {
 		}
 
 		if ok {
-			_, err := sc.WriteHelp(
-				cctx.Stderr,
-				IntrospectionOptions{Definitions: cctx.Definitions},
-			)
-
+			_, err := sc.WriteHelp(cctx.Stderr, cctx.introspectionOptions())
 			return err
 		}
 
@@ -48,11 +44,7 @@ func (sc ArgumentCommand) Run(ctx context.Context, cctx CommandContext) error {
 			return err
 		}
 
-		_, err = sc.WriteSynopsis(
-			cctx.Stderr,
-			IntrospectionOptions{Definitions: cctx.Definitions},
-		)
-
+		_, err = sc.WriteSynopsis(cctx.Stderr, cctx.introspectionOptions())
 		return err
 	}
 

--- a/x/cli/command.go
+++ b/x/cli/command.go
@@ -18,7 +18,15 @@ type CommandContext struct {
 
 	Definitions []CommandDefinition
 
-	args map[string]string
+	args    map[string]string
+	appName string
+}
+
+func (cctx CommandContext) introspectionOptions() IntrospectionOptions {
+	return IntrospectionOptions{
+		AppName:     cctx.appName,
+		Definitions: cctx.Definitions,
+	}
 }
 
 type argProvider map[string]string

--- a/x/cli/command.go
+++ b/x/cli/command.go
@@ -26,6 +26,7 @@ func (cctx CommandContext) introspectionOptions() IntrospectionOptions {
 	return IntrospectionOptions{
 		AppName:     cctx.appName,
 		Definitions: cctx.Definitions,
+		args:        cctx.args,
 	}
 }
 

--- a/x/cli/command.go
+++ b/x/cli/command.go
@@ -2,11 +2,10 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/upfluence/cfg"
-	"github.com/upfluence/cfg/internal/help"
-	"github.com/upfluence/cfg/internal/synopsis"
 )
 
 type CommandContext struct {
@@ -16,6 +15,8 @@ type CommandContext struct {
 	Stdin  io.Reader
 	Stdout io.Writer
 	Stderr io.Writer
+
+	Definitions []CommandDefinition
 
 	args map[string]string
 }
@@ -29,8 +30,8 @@ func (ap argProvider) Provide(_ context.Context, k string) (string, bool, error)
 }
 
 type Command interface {
-	WriteSynopsis(io.Writer) (int, error)
-	WriteHelp(io.Writer) (int, error)
+	WriteSynopsis(io.Writer, IntrospectionOptions) (int, error)
+	WriteHelp(io.Writer, IntrospectionOptions) (int, error)
 
 	Run(context.Context, CommandContext) error
 }
@@ -62,21 +63,10 @@ func (bc *baseCommand) Run(ctx context.Context, cctx CommandContext) error {
 		return bc.helpCmd.Run(ctx, cctx)
 	}
 
+	if bc.Command == nil {
+		_, err := fmt.Fprintf(cctx.Stderr, "command not implemented")
+		return err
+	}
+
 	return bc.Command.Run(ctx, cctx)
-}
-
-func StaticString(v string) func(io.Writer) (int, error) {
-	return func(w io.Writer) (int, error) { return io.WriteString(w, v) }
-}
-
-func HelpWriter(in interface{}) func(io.Writer) (int, error) {
-	return func(w io.Writer) (int, error) {
-		return help.DefaultWriter.Write(w, in)
-	}
-}
-
-func SynopsisWriter(in interface{}) func(io.Writer) (int, error) {
-	return func(w io.Writer) (int, error) {
-		return synopsis.DefaultWriter.Write(w, in)
-	}
 }

--- a/x/cli/command_test.go
+++ b/x/cli/command_test.go
@@ -11,10 +11,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type mockConfig1 struct {
+	Example string `flag:"e,example"`
+}
+
+type mockConfig2 struct {
+	Other string `flag:"o,other"`
+}
+
+type mockCommand struct {
+	Command
+}
+
+func (mc *mockCommand) WriteHelp(w io.Writer, opts IntrospectionOptions) (int, error) {
+	return mc.Command.WriteHelp(
+		w,
+		opts.withDefinition(
+			CommandDefinition{Configs: []interface{}{&mockConfig1{}}},
+		),
+	)
+}
+
 func TestRun(t *testing.T) {
 	staticCmd := StaticCommand{
 		Help:     StaticString("help foo"),
-		Synopsis: StaticString("foo synopsis"),
+		Synopsis: SynopsisWriter(&mockConfig1{}),
 		Execute: func(_ context.Context, cctx CommandContext) error {
 			_, err := io.WriteString(cctx.Stdout, "success")
 			return err
@@ -22,6 +43,21 @@ func TestRun(t *testing.T) {
 	}
 
 	subCmd := SubCommand{Commands: map[string]Command{"foo": staticCmd}}
+	nestedCmd := SubCommand{
+		Commands: map[string]Command{
+			"foo": subCmd,
+			"bar": &mockCommand{
+				Command: StaticCommand{
+					Help:     HelpWriter(&mockConfig2{}),
+					Synopsis: SynopsisWriter(&mockConfig2{}),
+					Execute: func(_ context.Context, cctx CommandContext) error {
+						_, err := io.WriteString(cctx.Stdout, "success")
+						return err
+					},
+				},
+			},
+		},
+	}
 
 	argCmd := ArgumentCommand{
 		Variable: "buz",
@@ -85,12 +121,12 @@ version      Print the app version
 			opts: []Option{WithCommand(argCmd)},
 			args: []string{"-y"},
 			wantErr: `no argument found for variable "buz", follow the synopsis:
-<buz> `,
+cli-test <buz> `,
 		},
 		{
 			opts:    []Option{WithCommand(argCmd)},
 			args:    []string{"-h"},
-			wantErr: "usage: <buz> ",
+			wantErr: "usage: cli-test <buz> ",
 		},
 		{
 			args:    []string{"foo"},
@@ -108,18 +144,50 @@ version Print the app version `,
 		{
 			args: []string{"-h"},
 			opts: []Option{WithCommand(subCmd)},
-			wantErr: `usage: <arg_1>
+			wantErr: `usage: cli-test <arg_1>
 Available sub commands:
 foo help foo
 help Print this message
 version Print the app version `,
+		},
+		{
+			args: []string{"-h"},
+			opts: []Option{WithCommand(nestedCmd)},
+			wantErr: `usage: cli-test <arg_1>
+Available sub commands:
+bar usage: [-e, --example] [-o, --other]
+foo usage: <arg_1>
+help Print this message
+version Print the app version `,
+		},
+		{
+			args: []string{"foo", "-h"},
+			opts: []Option{WithCommand(nestedCmd)},
+			wantErr: `usage: cli-test <arg_1> <arg_2>
+Available sub commands:
+foo help foo
+help Print this message
+version Print the app version `,
+		},
+		{
+			args: []string{"bar", "-h"},
+			opts: []Option{WithCommand(nestedCmd)},
+			wantErr: `usage: cli-test <arg_1> [-e, --example] [-o, --other]
+Arguments:
+- Example: string (env: EXAMPLE, flag: -e, --example)
+- Other: string (env: OTHER, flag: -o, --other) `,
+		},
+		{
+			args:    []string{"foo", "foo", "-h"},
+			opts:    []Option{WithCommand(nestedCmd)},
+			wantErr: `usage: cli-test <arg_1> <arg_2> help foo`,
 		},
 	} {
 		var (
 			outBuf bytes.Buffer
 			errBuf bytes.Buffer
 
-			a = NewApp(tt.opts...)
+			a = NewApp(append([]Option{WithName("cli-test")}, tt.opts...)...)
 		)
 
 		a.args = tt.args

--- a/x/cli/help_command.go
+++ b/x/cli/help_command.go
@@ -11,22 +11,39 @@ type helpCommand struct {
 	cmd Command
 }
 
-func (hc *helpCommand) WriteHelp(w io.Writer) (int, error) {
+func (hc *helpCommand) WriteHelp(w io.Writer, _ IntrospectionOptions) (int, error) {
 	return io.WriteString(w, "Print this message")
 }
 
-func (hc *helpCommand) WriteSynopsis(io.Writer) (int, error) { return 0, nil }
+func (hc *helpCommand) WriteSynopsis(io.Writer, IntrospectionOptions) (int, error) { return 0, nil }
 
 func (hc *helpCommand) Run(_ context.Context, cctx CommandContext) error {
-	var writeTo = func(w io.Writer) (int, error) {
-		return io.WriteString(w, defaultHelp)
-	}
+	var writeTo = writeUsage
 
 	if hc.cmd != nil {
 		writeTo = hc.cmd.WriteHelp
+	} else if len(cctx.Definitions) == 0 {
+		writeTo = StaticString(defaultHelp)
 	}
 
-	_, err := writeTo(cctx.Stdout)
+	_, err := writeTo(
+		cctx.Stderr,
+		IntrospectionOptions{Definitions: cctx.Definitions},
+	)
 
 	return err
+}
+
+type helpConfig struct {
+	Help bool `flag:"h,help" help:"Display this message"`
+}
+
+func isHelpRequested(ctx context.Context, cctx CommandContext) (bool, error) {
+	var c helpConfig
+
+	if err := cctx.Configurator.Populate(ctx, &c); err != nil {
+		return false, err
+	}
+
+	return c.Help, nil
 }

--- a/x/cli/help_command.go
+++ b/x/cli/help_command.go
@@ -26,11 +26,7 @@ func (hc *helpCommand) Run(_ context.Context, cctx CommandContext) error {
 		writeTo = StaticString(defaultHelp)
 	}
 
-	_, err := writeTo(
-		cctx.Stderr,
-		IntrospectionOptions{Definitions: cctx.Definitions},
-	)
-
+	_, err := writeTo(cctx.Stderr, cctx.introspectionOptions())
 	return err
 }
 

--- a/x/cli/introspection.go
+++ b/x/cli/introspection.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/upfluence/cfg/internal/help"
+	"github.com/upfluence/cfg/internal/synopsis"
+)
+
+type CommandDefinition struct {
+	Args    []string
+	Configs []interface{}
+}
+
+type IntrospectionOptions struct {
+	Definitions []CommandDefinition
+	Short       bool
+}
+
+func (io IntrospectionOptions) withDefinition(def CommandDefinition) IntrospectionOptions {
+	return IntrospectionOptions{
+		Definitions: append(io.Definitions, def),
+		Short:       io.Short,
+	}
+}
+
+type IntrospectionFunc func(io.Writer, IntrospectionOptions) (int, error)
+
+func StaticString(v string) IntrospectionFunc {
+	return func(w io.Writer, _ IntrospectionOptions) (int, error) {
+		return io.WriteString(w, v)
+	}
+}
+
+func HelpWriter(in interface{}) IntrospectionFunc {
+	return func(w io.Writer, opts IntrospectionOptions) (int, error) {
+		return writeHelp(
+			w,
+			opts.withDefinition(CommandDefinition{Configs: []interface{}{in}}),
+		)
+	}
+}
+
+func writeHelp(w io.Writer, opts IntrospectionOptions) (int, error) {
+	var n int
+
+	nn, err := io.WriteString(w, "usage: ")
+	n += nn
+
+	if err != nil {
+		return n, err
+	}
+
+	nn, err = writeSynopsis(w, opts)
+	n += nn
+
+	if err != nil || opts.Short {
+		return n, err
+	}
+
+	nn, err = io.WriteString(w, "\n")
+	n += nn
+
+	if err != nil || len(opts.Definitions) == 0 {
+		return n, err
+	}
+
+	for _, c := range opts.Definitions[len(opts.Definitions)-1].Configs {
+		nn, err := help.DefaultWriter.Write(w, c)
+		n += nn
+
+		if err != nil {
+			return n, err
+		}
+	}
+
+	return n, nil
+}
+
+func SynopsisWriter(in interface{}) IntrospectionFunc {
+	return func(w io.Writer, opts IntrospectionOptions) (int, error) {
+		return writeSynopsis(
+			w,
+			opts.withDefinition(CommandDefinition{Configs: []interface{}{in}}),
+		)
+	}
+}
+
+func writeSynopsis(w io.Writer, opts IntrospectionOptions) (int, error) {
+	var n int
+
+	for _, def := range opts.Definitions {
+		for _, arg := range def.Args {
+			nn, err := fmt.Fprintf(w, "<%s> ", arg)
+			n += nn
+
+			if err != nil {
+				return n, err
+			}
+		}
+
+		for _, cfg := range def.Configs {
+			nn, err := synopsis.DefaultWriter.Write(w, cfg)
+			n += nn
+
+			if err != nil {
+				return n, err
+			}
+		}
+	}
+
+	return n, nil
+}
+
+func writeUsage(w io.Writer, opts IntrospectionOptions) (int, error) {
+	opts.Short = true
+
+	return writeHelp(w, opts)
+}

--- a/x/cli/introspection.go
+++ b/x/cli/introspection.go
@@ -17,6 +17,16 @@ type IntrospectionOptions struct {
 	AppName     string
 	Definitions []CommandDefinition
 	Short       bool
+
+	args map[string]string
+}
+
+func (io IntrospectionOptions) argName(arg string) string {
+	if v, ok := io.args[arg]; ok {
+		return v
+	}
+
+	return fmt.Sprintf("<%s>", arg)
 }
 
 func (io IntrospectionOptions) withDefinition(def CommandDefinition) IntrospectionOptions {
@@ -24,6 +34,7 @@ func (io IntrospectionOptions) withDefinition(def CommandDefinition) Introspecti
 		AppName:     io.AppName,
 		Definitions: append(io.Definitions, def),
 		Short:       io.Short,
+		args:        io.args,
 	}
 }
 
@@ -130,7 +141,7 @@ func writeSynopsis(w io.Writer, opts IntrospectionOptions) (int, error) {
 
 	for _, def := range opts.Definitions {
 		for _, arg := range def.Args {
-			nn, err := fmt.Fprintf(w, "<%s> ", arg)
+			nn, err := fmt.Fprintf(w, "%s ", opts.argName(arg))
 			n += nn
 
 			if err != nil {

--- a/x/cli/option.go
+++ b/x/cli/option.go
@@ -37,28 +37,64 @@ func defaultOptions() *options {
 }
 
 func (o *options) command() Command {
-	cmd := o.cmd
-
-	versionCmd := &versionCommand{name: o.name, version: o.version}
-	helpCmd := &helpCommand{cmd: cmd}
-
-	if cmd == nil {
-		cmd = SubCommand{}
-	}
+	cmd := o.wrapCommand(o.cmd)
 
 	if scmd, ok := cmd.(SubCommand); ok {
-		if _, ok := scmd["version"]; !ok {
-			scmd["version"] = versionCmd
+		if _, ok := scmd.Commands["version"]; !ok {
+			scmd.Commands["version"] = o.versionCommand()
 		}
 
-		if _, ok := scmd["help"]; !ok {
-			scmd["help"] = helpCmd
+		if _, ok := scmd.Commands["help"]; !ok {
+			scmd.Commands["help"] = &helpCommand{cmd: cmd}
 		}
+	}
+
+	return cmd
+}
+
+func (o *options) versionCommand() *versionCommand {
+	return &versionCommand{name: o.name, version: o.version}
+}
+
+func (o *options) wrapCommand(cmd Command) Command {
+	helpCmd := &helpCommand{cmd: cmd}
+
+	switch tcmd := cmd.(type) {
+	case nil:
+		versionCmd := o.versionCommand()
+		return &baseCommand{
+			Command: SubCommand{
+				Variable: "verb",
+				Commands: map[string]Command{"version": versionCmd, "help": helpCmd},
+			},
+			helpCmd:    helpCmd,
+			versionCmd: versionCmd,
+		}
+	case SubCommand:
+		if tcmd.Commands == nil {
+			tcmd.Commands = make(map[string]Command, 1)
+		}
+
+		if _, ok := tcmd.Commands["help"]; !ok {
+			tcmd.Commands["help"] = helpCmd
+		}
+
+		for k, cmd := range tcmd.Commands {
+			tcmd.Commands[k] = o.wrapCommand(cmd)
+		}
+
+		return tcmd
+	case ArgumentCommand:
+		tcmd.Command = o.wrapCommand(tcmd.Command)
+
+		return tcmd
+	case *baseCommand:
+		return tcmd
 	}
 
 	return &baseCommand{
 		Command:    cmd,
 		helpCmd:    helpCmd,
-		versionCmd: versionCmd,
+		versionCmd: o.versionCommand(),
 	}
 }

--- a/x/cli/static_command.go
+++ b/x/cli/static_command.go
@@ -6,26 +6,26 @@ import (
 )
 
 type StaticCommand struct {
-	Help     func(io.Writer) (int, error)
-	Synopsis func(io.Writer) (int, error)
+	Help     IntrospectionFunc
+	Synopsis IntrospectionFunc
 
 	Execute func(context.Context, CommandContext) error
 }
 
-func (sc StaticCommand) WriteHelp(w io.Writer) (int, error) {
+func (sc StaticCommand) WriteHelp(w io.Writer, opts IntrospectionOptions) (int, error) {
 	if sc.Help == nil {
-		return io.WriteString(w, "no help provided")
+		return writeUsage(w, opts)
 	}
 
-	return sc.Help(w)
+	return sc.Help(w, opts)
 }
 
-func (sc StaticCommand) WriteSynopsis(w io.Writer) (int, error) {
+func (sc StaticCommand) WriteSynopsis(w io.Writer, opts IntrospectionOptions) (int, error) {
 	if sc.Synopsis == nil {
-		return 0, nil
+		return writeSynopsis(w, opts)
 	}
 
-	return sc.Synopsis(w)
+	return sc.Synopsis(w, opts)
 }
 
 func (sc StaticCommand) Run(ctx context.Context, cctx CommandContext) error {

--- a/x/cli/sub_command.go
+++ b/x/cli/sub_command.go
@@ -161,6 +161,10 @@ func (sc SubCommand) Run(ctx context.Context, cctx CommandContext) error {
 	if len(cctx.Args) > 0 {
 		cmdKey = cctx.Args[0]
 		args = cctx.Args[1:]
+
+		if sc.Variable != "" {
+			cctx.args[sc.Variable] = cmdKey
+		}
 	}
 
 	cmd, ok := sc.Commands[cmdKey]

--- a/x/cli/sub_command.go
+++ b/x/cli/sub_command.go
@@ -8,61 +8,134 @@ import (
 	"text/tabwriter"
 )
 
-type SubCommand map[string]Command
+type SubCommand struct {
+	Variable string
 
-func (sc SubCommand) WriteHelp(w io.Writer) (int, error) {
-	n, err := io.WriteString(w, "Available sub commands: \n")
+	ShortHelp IntrospectionFunc
+
+	Commands map[string]Command
+}
+
+func (sc SubCommand) variable(defs []CommandDefinition) string {
+	if sc.Variable != "" {
+		return sc.Variable
+	}
+
+	var n int
+
+	for _, def := range defs {
+		n += len(def.Args)
+	}
+
+	return fmt.Sprintf("arg_%d", n+1)
+
+}
+
+func (sc SubCommand) definition(defs []CommandDefinition) CommandDefinition {
+	return CommandDefinition{Args: []string{sc.variable(defs)}}
+}
+
+func (sc SubCommand) writeUsage(w io.Writer, opts IntrospectionOptions) (int, error) {
+	var n, err = writeUsage(
+		w,
+		opts.withDefinition(sc.definition(opts.Definitions)),
+	)
 
 	if err != nil {
 		return n, err
 	}
 
-	nn, err := sc.WriteSynopsis(w)
+	nn, err := io.WriteString(w, "\n")
+	n += nn
 
-	return n + nn, err
+	return n, err
 }
 
-func (sc SubCommand) WriteSynopsis(w io.Writer) (int, error) {
+func (sc SubCommand) WriteHelp(w io.Writer, opts IntrospectionOptions) (int, error) {
 	var n int
 
-	tw := tabwriter.NewWriter(w, 4, 4, 2, ' ', tabwriter.TabIndent)
+	if sc.ShortHelp != nil {
+		nn, err := sc.ShortHelp(w, opts)
+		n += nn
 
-	ks := make([]string, 0, len(sc))
+		if err != nil {
+			return n, err
+		}
+	}
 
-	for k := range sc {
+	if sc.ShortHelp == nil && opts.Short {
+		nn, err := sc.writeUsage(w, opts)
+		n += nn
+
+		if err != nil {
+			return n, err
+		}
+	}
+
+	if opts.Short {
+		return 0, nil
+	}
+
+	if sc.ShortHelp != nil {
+		nn, err := io.WriteString(w, "\n")
+		n += nn
+
+		if err != nil {
+			return n, err
+		}
+	} else {
+		nn, err := sc.writeUsage(w, opts)
+		n += nn
+
+		if err != nil {
+			return n, err
+		}
+	}
+
+	nn, err := io.WriteString(w, "Available sub commands: \n")
+	n += nn
+
+	if err != nil {
+		return n, err
+	}
+
+	nn, err = sc.WriteSynopsis(w, opts)
+	n += nn
+
+	return n, err
+}
+
+func (sc SubCommand) WriteSynopsis(w io.Writer, opts IntrospectionOptions) (int, error) {
+	if opts.Short {
+		return fmt.Fprintf(w, "<%s>", sc.variable(opts.Definitions))
+	}
+
+	var (
+		n int
+
+		tw = tabwriter.NewWriter(w, 4, 4, 2, ' ', tabwriter.TabIndent)
+		ks = make([]string, 0, len(sc.Commands))
+	)
+
+	opts = opts.withDefinition(sc.definition(opts.Definitions))
+	opts.Short = true
+
+	for k := range sc.Commands {
 		ks = append(ks, k)
 	}
 
 	sort.Strings(ks)
 
 	for _, k := range ks {
-		cmd := sc[k]
+		cmd := sc.Commands[k]
 		nn, err := fmt.Fprintf(tw, "\t%s  \t  ", k)
-
 		n += nn
 
 		if err != nil {
 			return n, err
 		}
 
-		nn, err = cmd.WriteHelp(tw)
-
-		n += nn
-
-		if err != nil {
-			return n, err
-		}
-
-		nn, err = io.WriteString(tw, "  ")
-
-		n += nn
-
-		if err != nil {
-			return n, err
-		}
-
-		nn, err = cmd.WriteSynopsis(tw)
-
+		nn, err = cmd.WriteHelp(tw, opts)
 		n += nn
 
 		if err != nil {
@@ -70,7 +143,6 @@ func (sc SubCommand) WriteSynopsis(w io.Writer) (int, error) {
 		}
 
 		nn, err = io.WriteString(tw, "\n")
-
 		n += nn
 
 		if err != nil {
@@ -92,9 +164,26 @@ func (sc SubCommand) Run(ctx context.Context, cctx CommandContext) error {
 		args = cctx.Args[1:]
 	}
 
-	cmd, ok := sc[cmdKey]
+	cmd, ok := sc.Commands[cmdKey]
 
 	if !ok {
+		if cmdKey == "" {
+			ok, err := isHelpRequested(ctx, cctx)
+
+			if err != nil {
+				return err
+			}
+
+			if ok {
+				_, err := sc.WriteHelp(
+					cctx.Stderr,
+					IntrospectionOptions{Definitions: cctx.Definitions},
+				)
+
+				return err
+			}
+		}
+
 		if _, err := fmt.Fprintf(
 			cctx.Stderr,
 			"unknown command %q, available commands:\n",
@@ -103,10 +192,15 @@ func (sc SubCommand) Run(ctx context.Context, cctx CommandContext) error {
 			return err
 		}
 
-		_, err := sc.WriteSynopsis(cctx.Stderr)
+		_, err := sc.WriteSynopsis(
+			cctx.Stderr,
+			IntrospectionOptions{Definitions: cctx.Definitions},
+		)
+
 		return err
 	}
 
+	cctx.Definitions = append(cctx.Definitions, sc.definition(cctx.Definitions))
 	cctx.Args = args
 
 	return cmd.Run(ctx, cctx)

--- a/x/cli/sub_command.go
+++ b/x/cli/sub_command.go
@@ -117,8 +117,7 @@ func (sc SubCommand) WriteSynopsis(w io.Writer, opts IntrospectionOptions) (int,
 		ks = make([]string, 0, len(sc.Commands))
 	)
 
-	opts = opts.withDefinition(sc.definition(opts.Definitions))
-	opts.Short = true
+	opts = IntrospectionOptions{Short: true}
 
 	for k := range sc.Commands {
 		ks = append(ks, k)
@@ -175,11 +174,7 @@ func (sc SubCommand) Run(ctx context.Context, cctx CommandContext) error {
 			}
 
 			if ok {
-				_, err := sc.WriteHelp(
-					cctx.Stderr,
-					IntrospectionOptions{Definitions: cctx.Definitions},
-				)
-
+				_, err = sc.WriteHelp(cctx.Stderr, cctx.introspectionOptions())
 				return err
 			}
 		}
@@ -192,11 +187,7 @@ func (sc SubCommand) Run(ctx context.Context, cctx CommandContext) error {
 			return err
 		}
 
-		_, err := sc.WriteSynopsis(
-			cctx.Stderr,
-			IntrospectionOptions{Definitions: cctx.Definitions},
-		)
-
+		_, err := sc.WriteSynopsis(cctx.Stderr, cctx.introspectionOptions())
 		return err
 	}
 

--- a/x/cli/sub_command.go
+++ b/x/cli/sub_command.go
@@ -28,7 +28,6 @@ func (sc SubCommand) variable(defs []CommandDefinition) string {
 	}
 
 	return fmt.Sprintf("arg_%d", n+1)
-
 }
 
 func (sc SubCommand) definition(defs []CommandDefinition) CommandDefinition {

--- a/x/cli/version_command.go
+++ b/x/cli/version_command.go
@@ -13,9 +13,9 @@ type versionCommand struct {
 	version string
 }
 
-func (vc *versionCommand) WriteSynopsis(io.Writer) (int, error) { return 0, nil }
+func (vc *versionCommand) WriteSynopsis(io.Writer, IntrospectionOptions) (int, error) { return 0, nil }
 
-func (vc *versionCommand) WriteHelp(w io.Writer) (int, error) {
+func (vc *versionCommand) WriteHelp(w io.Writer, _ IntrospectionOptions) (int, error) {
 	return io.WriteString(w, "Print the app version")
 }
 


### PR DESCRIPTION
### What does this PR do?

In order to have a more flexible way of building meaningful / comprehensive help and synopsis messages. I added a IntrospectionOptiosn that carries the stack of commands primitives (args and config to be parsed)

### What are the observable changes?

For the sake of testing:

i wrote a test program under `example/kubectl` (subset of the command of the actual kubectl).

```
$ go build -o kubectl ./example/kubectl

$ ./kubectl -h
usage: kubectl <verb>
Available sub commands:
	describe      describe remote object
	edit          edit remote object
	help          Print this message
	version       Print the app version

$ ./kubectl describe pod
no argument found for variable "resource_name", follow the synopsis:
kubectl describe pod <resource_name>

$ ./kubectl describe pod -h
usage: kubectl describe pod <resource_name>
describe remote object

$ ./kubectl describe pod foobar -n buz
action="describe" namespace="buz" ressourceType="pod" ressourceName="foobar"
```


### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

⚠️ this PR does break the compatibilty for both:

* SubCommand format (it use to be a type def on map[string]Command )
* The Command interface change the API of WriteHelp and WriteSynopsis