### PR TITLE
x/cli: Add SubCommand function on command context

### DIFF
--- a/x/cli/app.go
+++ b/x/cli/app.go
@@ -88,15 +88,7 @@ func (a *App) commandContext() CommandContext {
 		)
 	)
 
-	return CommandContext{
-		Configurator: cfg.NewConfigurator(ps...),
-		Args:         cmds,
-		Stdin:        os.Stdin,
-		Stdout:       os.Stdout,
-		Stderr:       os.Stderr,
-		args:         args,
-		appName:      a.name,
-	}
+	return newCommandContext(a.name, cmds, args, cfg.NewConfigurator(ps...))
 }
 
 func (a *App) Run(ctx context.Context) {

--- a/x/cli/command.go
+++ b/x/cli/command.go
@@ -4,31 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-
-	"github.com/upfluence/cfg"
 )
-
-type CommandContext struct {
-	Configurator cfg.Configurator
-	Args         []string
-
-	Stdin  io.Reader
-	Stdout io.Writer
-	Stderr io.Writer
-
-	Definitions []CommandDefinition
-
-	args    map[string]string
-	appName string
-}
-
-func (cctx CommandContext) introspectionOptions() IntrospectionOptions {
-	return IntrospectionOptions{
-		AppName:     cctx.appName,
-		Definitions: cctx.Definitions,
-		args:        cctx.args,
-	}
-}
 
 type argProvider map[string]string
 

--- a/x/cli/command_context.go
+++ b/x/cli/command_context.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/upfluence/cfg"
+)
+
+type CommandContext struct {
+	Configurator cfg.Configurator
+	Args         []string
+
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	Definitions []CommandDefinition
+
+	args    map[string]string
+	appName string
+
+	env []string
+	wd  string
+}
+
+func newCommandContext(name string, cmds []string, args map[string]string, c cfg.Configurator) CommandContext {
+	var wd, _ = os.Getwd()
+
+	return CommandContext{
+		Configurator: c,
+		Args:         cmds,
+		Stdin:        os.Stdin,
+		Stdout:       os.Stdout,
+		Stderr:       os.Stderr,
+		args:         args,
+		appName:      name,
+		wd:           wd,
+		env:          os.Environ(),
+	}
+}
+
+func (cctx CommandContext) SubCommand(ctx context.Context, n string, args ...string) *exec.Cmd {
+	var cmd = exec.CommandContext(ctx, n, args...)
+
+	cmd.Stdin = cctx.Stdin
+	cmd.Stdout = cctx.Stdout
+	cmd.Stderr = cctx.Stderr
+	cmd.Env = cctx.env
+	cmd.Dir = cctx.wd
+
+	return cmd
+}
+
+func (cctx CommandContext) introspectionOptions() IntrospectionOptions {
+	return IntrospectionOptions{
+		AppName:     cctx.appName,
+		Definitions: cctx.Definitions,
+		args:        cctx.args,
+	}
+}

--- a/x/cli/command_context_test.go
+++ b/x/cli/command_context_test.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubCommand(t *testing.T) {
+	os.Setenv("FOO", "bar")
+
+	var (
+		buf bytes.Buffer
+
+		cctx = newCommandContext("", nil, nil, nil)
+	)
+
+	cctx.Stdout = &buf
+	cctx.Stderr = &buf
+
+	err := cctx.SubCommand(
+		context.Background(),
+		"/bin/bash",
+		"-c",
+		`echo "$FOO"`,
+	).Run()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bar\n", buf.String())
+}


### PR DESCRIPTION
### What does this PR do?

A common use case for x/cli is to write cli tool that wrap the execution of other cli tools,  Subcommand would allow the ability to simply pipe all the context to the sub commands (working directory, envs and i/o)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
