### PR TITLE
provider/flags: Accept and treat accordingly flags with = sign

### DIFF
--- a/provider/flags/provider.go
+++ b/provider/flags/provider.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/upfluence/cfg/provider"
@@ -33,14 +34,30 @@ func parseFlags(args []string) map[string]string {
 
 	for _, arg := range args {
 		if v, ok := parseArg(arg); ok {
-			key = v
 			val := "true"
-			inParam = true
 
-			if strings.HasPrefix(v, "no-") && len(v) > 3 {
-				key = strings.TrimPrefix(v, "no-")
-				val = "false"
+			if strings.Contains(v, "=") {
+				if inParam {
+					res[key] = val
+				}
+
+				vs := strings.SplitN(v, "=", 2)
 				inParam = false
+				key = vs[0]
+				val = vs[1]
+
+				if v, err := strconv.Unquote(val); err == nil {
+					val = v
+				}
+			} else {
+				key = v
+				inParam = true
+
+				if strings.HasPrefix(v, "no-") && len(v) > 3 {
+					key = strings.TrimPrefix(v, "no-")
+					val = "false"
+					inParam = false
+				}
 			}
 
 			res[key] = val

--- a/provider/flags/provider_test.go
+++ b/provider/flags/provider_test.go
@@ -71,6 +71,15 @@ func TestParseFlags(t *testing.T) {
 				"foobar": "foo",
 			},
 		},
+		{
+			name: "has multiple type format (2)",
+			in:   []string{"--fuz", "--foo=biz", "--biz=\"buz\""},
+			out: map[string]string{
+				"foo": "biz",
+				"biz": "buz",
+				"fuz": "true",
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if out := parseFlags(tt.in); !reflect.DeepEqual(out, tt.out) {

--- a/x/cli/app.go
+++ b/x/cli/app.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/upfluence/cfg"
 	"github.com/upfluence/cfg/provider"
@@ -63,6 +64,11 @@ func (a *App) parseArgs() ([]string, []string) {
 		if arg[0] == '-' {
 			isFlag = true
 			flags = append(flags, arg)
+
+			if strings.Contains(arg, "=") {
+				isFlag = false
+			}
+
 			continue
 		}
 

--- a/x/cli/app_test.go
+++ b/x/cli/app_test.go
@@ -33,6 +33,16 @@ func TestParseArgs(t *testing.T) {
 			wantFlags: []string{"-foo"},
 			wantCmds:  []string{"buz", "--", "biz", "-fuz"},
 		},
+		{
+			in:        []string{"--namespace", "foo", "buz", "-foo"},
+			wantFlags: []string{"--namespace", "foo", "-foo"},
+			wantCmds:  []string{"buz"},
+		},
+		{
+			in:        []string{"--namespace=\"foo\"", "buz", "-foo"},
+			wantFlags: []string{"--namespace=\"foo\"", "-foo"},
+			wantCmds:  []string{"buz"},
+		},
 	} {
 		a := &App{args: tt.in}
 


### PR DESCRIPTION
### What does this PR do?

It should accept flags like:

`--foo=bar`  and `--foo="buz"`

Fixes #17 

### What are the observable changes?

```
$ ./kubectl --namespace=foo describe describe foo bar
action="describe" namespace="foo" ressourceType="describe" ressourceName="foo"
```

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
