### PR TITLE
Improve quoting awarness whilst parsing flags and config values

### DIFF
--- a/configurator_test.go
+++ b/configurator_test.go
@@ -168,6 +168,14 @@ type mapStringIntStruct struct {
 	Map map[string]int `mock:"map"`
 }
 
+type mapStringStringStruct struct {
+	Map map[string]string `mock:"map"`
+}
+
+type mapStringStringsStruct struct {
+	Map map[string][]string `mock:"map"`
+}
+
 type skipStruct struct {
 	Foo string `mock:"-"`
 }
@@ -310,6 +318,28 @@ func TestConfigurator(t *testing.T) {
 			},
 			dataAssertion: deepEqual(&mapStringIntStruct{
 				Map: map[string]int{"foo": 1, "bar": 2, "buz": 3},
+			}),
+			errAssertion: noError,
+		},
+		testCase{
+			caseName: "advanced-map",
+			input:    &mapStringStringStruct{},
+			provider: &mockProvider{
+				st: map[string]string{"map": "foo='nested=k,v=z'"},
+			},
+			dataAssertion: deepEqual(&mapStringStringStruct{
+				Map: map[string]string{"foo": "nested=k,v=z"},
+			}),
+			errAssertion: noError,
+		},
+		testCase{
+			caseName: "advanced-map-2",
+			input:    &mapStringStringsStruct{},
+			provider: &mockProvider{
+				st: map[string]string{"map": "foo='bar,buz',buz=biz"},
+			},
+			dataAssertion: deepEqual(&mapStringStringsStruct{
+				Map: map[string][]string{"foo": {"bar", "buz"}, "buz": {"biz"}},
 			}),
 			errAssertion: noError,
 		},

--- a/internal/stringutil/split.go
+++ b/internal/stringutil/split.go
@@ -1,0 +1,66 @@
+package stringutil
+
+import (
+	"errors"
+	"unicode"
+)
+
+const zeroRune = rune(0)
+
+var errNotValid = errors.New("Quotes did not terminate")
+
+func Split(str string, r rune) ([]string, error) {
+	var (
+		parts      []string
+		cur        string
+		isRune     bool
+		quoteAdded bool
+
+		lastQuote = zeroRune
+		lastSplit = -1
+	)
+
+	for i, c := range str {
+		switch {
+		case c == lastQuote:
+			lastQuote = zeroRune
+
+			if quoteAdded {
+				cur += string(c)
+				quoteAdded = false
+			}
+		case lastQuote != zeroRune:
+			cur += string(c)
+		case unicode.In(c, unicode.Quotation_Mark):
+			isRune = false
+			lastQuote = c
+
+			if lastSplit != i-1 {
+				quoteAdded = true
+				cur += string(c)
+			}
+		case c == r:
+			if 0 == i || isRune {
+				continue
+			}
+
+			lastSplit = i
+			isRune = true
+			parts = append(parts, cur)
+			cur = ""
+		default:
+			isRune = false
+			cur += string(c)
+		}
+	}
+
+	if lastQuote != zeroRune {
+		return nil, errNotValid
+	}
+
+	if len(cur) != 0 {
+		parts = append(parts, cur)
+	}
+
+	return parts, nil
+}

--- a/internal/stringutil/split_test.go
+++ b/internal/stringutil/split_test.go
@@ -1,0 +1,58 @@
+package stringutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplit(t *testing.T) {
+	for _, tt := range []struct {
+		inStr  string
+		inRune rune
+
+		wantRes []string
+		wantErr error
+	}{
+		{
+			inStr:   "foo,bar",
+			inRune:  ',',
+			wantRes: []string{"foo", "bar"},
+		},
+		{
+			inStr:   "'foo,bar',bar",
+			inRune:  ',',
+			wantRes: []string{"foo,bar", "bar"},
+		},
+		{
+			inStr:   "'foo,\"bar,biz\"',bar",
+			inRune:  ',',
+			wantRes: []string{"foo,\"bar,biz\"", "bar"},
+		},
+		{
+			inStr:   ",",
+			inRune:  ',',
+			wantRes: nil,
+		},
+		{
+			inStr:   "foo,,",
+			inRune:  ',',
+			wantRes: []string{"foo"},
+		},
+		{
+			inStr:   "foo,\"fuz",
+			inRune:  ',',
+			wantErr: errNotValid,
+		},
+		{
+			inStr:   "foo='nested=k,v=z'",
+			inRune:  ',',
+			wantRes: []string{"foo='nested=k,v=z'"},
+		},
+	} {
+		got, err := Split(tt.inStr, tt.inRune)
+
+		assert.Equal(t, tt.wantErr, err)
+		assert.Equal(t, tt.wantRes, got)
+	}
+}

--- a/provider/flags/provider.go
+++ b/provider/flags/provider.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/upfluence/cfg/internal/stringutil"
 	"github.com/upfluence/cfg/provider"
 )
 
@@ -36,12 +37,12 @@ func parseFlags(args []string) map[string]string {
 		if v, ok := parseArg(arg); ok {
 			val := "true"
 
-			if strings.Contains(v, "=") {
+			switch vs, _ := stringutil.Split(v, '='); len(vs) {
+			case 2:
 				if inParam {
 					res[key] = val
 				}
 
-				vs := strings.SplitN(v, "=", 2)
 				inParam = false
 				key = vs[0]
 				val = vs[1]
@@ -49,7 +50,7 @@ func parseFlags(args []string) map[string]string {
 				if v, err := strconv.Unquote(val); err == nil {
 					val = v
 				}
-			} else {
+			case 1:
 				key = v
 				inParam = true
 

--- a/provider/flags/provider_test.go
+++ b/provider/flags/provider_test.go
@@ -80,6 +80,15 @@ func TestParseFlags(t *testing.T) {
 				"fuz": "true",
 			},
 		},
+		{
+			name: "has multiple type format (2)",
+			in:   []string{"--fuz", "--foo=biz", "--biz=\"buz=bar\""},
+			out: map[string]string{
+				"foo": "biz",
+				"biz": "buz=bar",
+				"fuz": "true",
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if out := parseFlags(tt.in); !reflect.DeepEqual(out, tt.out) {


### PR DESCRIPTION
### What does this PR do?

This PR allows a better parsing of quoted config values. Before this PR the quoting was not respected now you can define more complex values.

### What are the observable changes?


Checkout the configurator tests for some examples

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
