### PR TITLE
x/multistage: Helper to have multiple stage configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.19.x', '1.18.x', '1.17.x' ]
+        go: [ '1.20.x', '1.19.x' ]
     steps:
       - name: Install Go ${{ matrix.go }}
         uses: actions/setup-go@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v2
         with:
-          go-version: v1.19
+          go-version: v1.20
       - name: Check out code
         uses: actions/checkout@v1
       - name: golanci-lint

--- a/help_configurator.go
+++ b/help_configurator.go
@@ -19,6 +19,13 @@ type helpConfigurator struct {
 	stderr io.Writer
 }
 
+func (hc *helpConfigurator) WithOptions(opts ...Option) Configurator {
+	dup := *hc
+	dup.configurator = hc.configurator.withOptions(opts)
+
+	return &dup
+}
+
 func (hc *helpConfigurator) Populate(ctx context.Context, in interface{}) error {
 	var cfg helpConfig
 
@@ -28,6 +35,7 @@ func (hc *helpConfigurator) Populate(ctx context.Context, in interface{}) error 
 
 	if cfg.Help {
 		_ = hc.PrintDefaults(in)
+
 		os.Exit(2)
 	}
 

--- a/provider/json/provider.go
+++ b/provider/json/provider.go
@@ -16,14 +16,24 @@ import (
 
 var ErrJSONMalformated = errors.New("Payload not formatted correctly")
 
+type DecodeFunc func(io.Reader, interface{}) error
+
+func jsonDecode(r io.Reader, v interface{}) error {
+	return json.NewDecoder(r).Decode(v)
+}
+
 type Provider struct {
 	store map[string]interface{}
 }
 
 func NewProviderFromReader(r io.Reader) provider.Provider {
+	return NewProviderFromReaderAndDecoder(r, jsonDecode)
+}
+
+func NewProviderFromReaderAndDecoder(r io.Reader, fn DecodeFunc) provider.Provider {
 	var v = make(map[string]interface{})
 
-	if err := json.NewDecoder(r).Decode(&v); err != nil {
+	if err := fn(r, &v); err != nil {
 		return provider.ProvideError("json", err)
 	}
 

--- a/x/cli/option.go
+++ b/x/cli/option.go
@@ -3,9 +3,12 @@ package cli
 import (
 	"os"
 
+	"github.com/upfluence/cfg"
 	"github.com/upfluence/cfg/provider"
 	"github.com/upfluence/cfg/provider/env"
 )
+
+type NewConfiguratorFunc func(...cfg.Option) cfg.Configurator
 
 type Option func(*options)
 
@@ -17,14 +20,24 @@ func WithCommand(cmd Command) Option {
 	return func(o *options) { o.cmd = cmd }
 }
 
+func WithConfiguratorOptions(opts ...cfg.Option) Option {
+	return func(o *options) { o.opts = append(o.opts, opts...) }
+}
+
+func WithNewConfiguratorFunc(fn NewConfiguratorFunc) Option {
+	return func(o *options) { o.newFunc = fn }
+}
+
 type options struct {
 	name string
 	args []string
 
 	version string
 
-	cmd Command
-	ps  []provider.Provider
+	cmd     Command
+	ps      []provider.Provider
+	opts    []cfg.Option
+	newFunc NewConfiguratorFunc
 }
 
 func defaultOptions() *options {
@@ -33,6 +46,7 @@ func defaultOptions() *options {
 		args:    os.Args[1:],
 		version: Version,
 		ps:      []provider.Provider{env.NewDefaultProvider()},
+		newFunc: cfg.NewConfiguratorWithOptions,
 	}
 }
 

--- a/x/multistage/configurator.go
+++ b/x/multistage/configurator.go
@@ -1,0 +1,83 @@
+package cfg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/upfluence/cfg"
+	"github.com/upfluence/cfg/provider"
+)
+
+type ProviderMode int
+
+const (
+	ProviderAppend ProviderMode = iota
+	ProviderReplace
+)
+
+type ConfigurationStage[T any] struct {
+	InitialConfig     T
+	Mode              ProviderMode
+	NextProvidersFunc func(T) []provider.Provider
+}
+
+func (cs ConfigurationStage[T]) Next(ctx context.Context, c cfg.Configurator) ([]provider.Provider, ProviderMode, error) {
+	v := cs.InitialConfig
+
+	if err := c.Populate(ctx, &v); err != nil {
+		return nil, ProviderAppend, err
+	}
+
+	return cs.NextProvidersFunc(v), cs.Mode, nil
+}
+
+type Stage interface {
+	Next(context.Context, cfg.Configurator) ([]provider.Provider, ProviderMode, error)
+}
+
+type Configurator struct {
+	Stages              []Stage
+	InitialConfigurator cfg.Configurator
+}
+
+func (c *Configurator) initialConfigurator() cfg.Configurator {
+	if c.InitialConfigurator == nil {
+		return cfg.NewDefaultConfigurator()
+	}
+
+	return c.InitialConfigurator
+}
+
+func (c *Configurator) Populate(ctx context.Context, v interface{}) error {
+	var tc = c.initialConfigurator()
+
+	for _, s := range c.Stages {
+		ps, m, err := s.Next(ctx, tc)
+
+		if err != nil {
+			return err
+		}
+
+		var optFunc func(...provider.Provider) cfg.Option
+
+		switch m {
+		case ProviderAppend:
+			optFunc = cfg.AppendProviders
+		case ProviderReplace:
+			optFunc = cfg.OverrideProviders
+		default:
+			return fmt.Errorf("unknown ProviderMode(%+v)", m)
+		}
+
+		tc = tc.WithOptions(optFunc(ps...))
+	}
+
+	return tc.Populate(ctx, v)
+}
+
+func (c *Configurator) WithOptions(opts ...cfg.Option) cfg.Configurator {
+	return &Configurator{
+		Stages:              c.Stages,
+		InitialConfigurator: c.initialConfigurator().WithOptions(opts...),
+	}
+}

--- a/x/multistage/configurator_test.go
+++ b/x/multistage/configurator_test.go
@@ -1,0 +1,71 @@
+package cfg
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/upfluence/cfg"
+	"github.com/upfluence/cfg/provider"
+	"github.com/upfluence/cfg/provider/json"
+)
+
+type config struct {
+	Foo string `json:"foo"`
+	Bar string `json:"bar"`
+}
+
+func jsonProvider(v string) provider.Provider {
+	return json.NewProviderFromReader(strings.NewReader(v))
+}
+
+func TestIntegration(t *testing.T) {
+	for _, tt := range []struct {
+		stages []Stage
+
+		want config
+	}{
+		{want: config{Foo: "bar"}},
+		{
+			stages: []Stage{
+				ConfigurationStage[config]{
+					NextProvidersFunc: func(c config) []provider.Provider {
+						return []provider.Provider{
+							jsonProvider(`{"bar":"buz"}`),
+						}
+					},
+				},
+			},
+			want: config{Foo: "bar", Bar: "buz"},
+		},
+		{
+			stages: []Stage{
+				ConfigurationStage[config]{
+					Mode: ProviderReplace,
+					NextProvidersFunc: func(c config) []provider.Provider {
+						return []provider.Provider{jsonProvider(`{"bar":"buz"}`)}
+					},
+				},
+			},
+			want: config{Bar: "buz"},
+		},
+	} {
+		c := Configurator{
+			Stages: tt.stages,
+			InitialConfigurator: cfg.NewConfigurator(
+				jsonProvider(`{"foo":"bar"}`),
+			),
+		}
+
+		var v config
+
+		err := c.Populate(context.Background(), &v)
+
+		require.NoError(t, err)
+
+		assert.Equal(t, tt.want, v)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This Configurator implementation allows you to have configuration that build on top of the previous configuration layer:

For example you want to consume config from a file and get that file configured from the flags; you could write it this way:

```go
type stage0Config struct {
  FromFile string `flag:"from-file"`
}

type stage1Config struct {
  Value int `json:"value"`
  OtherValue string `flag:"other-value"`
}

func main() {
   var c stage1Config

   cfg := multistage.Configurator{
      Stages: []multistage.Stage{
         multistage. ConfigurationStage[stage0Config]{
           NextProvidersFunc: func(c stage0Config) []provider.Provider {
             return json.NewProviderFromReader(os.Open(c.FromFile))
           }
         }
       }    
   }

   err := cfg.Populate(ctx, &c)

...
}
```
### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
